### PR TITLE
Change \donttest to \dontrun

### DIFF
--- a/R/pin_internal.R
+++ b/R/pin_internal.R
@@ -128,7 +128,7 @@ pin_birthplace_internal <- function(pin, birth_vector, birth_other_text){
 #' ## Also for multiple pin 
 #' ## (as long they are all of the same format)
 #' luhn_algo(c("12121212121", "19850504333"))
-#' \donttest{
+#' \dontrun{
 #' luhn_algo(c("12121212121", "850504333")) ## Different formats should fail!
 #' }
 #' 


### PR DESCRIPTION
Bug fix #70 

According to <http://r-pkgs.had.co.nz/man.html>:

> For the purpose of illustration, it’s often useful to include code that causes an error. \dontrun{} allows you to include code in the example 
> that is not run. (You used to be able to use \donttest{} for a similar purpose, but it’s no longer recommended because it actually is tested.)