### PR TITLE
Render README.md automatically and deploy GitHub pages

### DIFF
--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -44,7 +44,7 @@ jobs:
         if: success()
         uses: peter-evans/repository-dispatch@v1
         with:
-          token: ${{ secrets.REPO_GHA_PAT }}
+          token: ${{ secrets.ROPENGOV_ORG_KEY }}
           repository: ${{ github.repository }}
           event-type: trigger-pkgdown-workflow
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -44,7 +44,7 @@ jobs:
         if: success()
         uses: peter-evans/repository-dispatch@v1
         with:
-          token: ${{ secrets.ROPENGOV_ORG_KEY }}
+          token: ${{ secrets.REPO_GHA_PAT }}
           repository: ${{ github.repository }}
           event-type: trigger-pkgdown-workflow
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/rogtemplate-gh-pages.yaml
+++ b/.github/workflows/rogtemplate-gh-pages.yaml
@@ -35,8 +35,6 @@ jobs:
             ropengov/rogtemplate
             any::magick
 
-          needs: website
-
       - name: Build logo if not present and prepare template
         run: |
           # Check that logo is not present

--- a/.github/workflows/rogtemplate-gh-pages.yaml
+++ b/.github/workflows/rogtemplate-gh-pages.yaml
@@ -20,17 +20,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: |
-            magick
+          needs: website
+          extra-packages:
+            local::.
+            any::pkgdown
             ropengov/rogtemplate
+            any::magick
 
           needs: website
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(
 <!-- badges: end -->
 
 <br>
- 
+
 # sweidnumbr <a href='https://ropengov.github.io/sweidnumbr/'><img src='man/figures/logo.png' align="right" height="139" /></a>
 
 ## Introduction

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(
 <!-- badges: end -->
 
 <br>
-
+ 
 # sweidnumbr <a href='https://ropengov.github.io/sweidnumbr/'><img src='man/figures/logo.png' align="right" height="139" /></a>
 
 ## Introduction

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,58 @@
+---
+output: md_document
+---
+
+```{r, echo = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "README-"
+)
+```
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+<!-- badges: start -->
+[![rOG-badge](https://ropengov.github.io/rogtemplate/reference/figures/ropengov-badge.svg)](http://ropengov.org/)
+[![R-CMD-check](https://github.com/rOpenGov/sweidnumbr/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/rOpenGov/sweidnumbr/actions/workflows/R-CMD-check.yaml)
+[![codecov](https://codecov.io/gh/ropengov/sweidnumbr/branch/master/graph/badge.svg)](https://codecov.io/gh/ropengov/sweidnumbr) 
+[![rstudio mirror downloads](http://cranlogs.r-pkg.org/badges/grand-total/sweidnumbr)](https://github.com/metacran/cranlogs.app)
+[![cran version](http://www.r-pkg.org/badges/version/sweidnumbr)](https://CRAN.R-project.org/package=sweidnumbr)
+<!-- badges: end -->
+
+<br>
+
+# sweidnumbr <a href='https://ropengov.github.io/sweidnumbr/'><img src='man/figures/logo.png' align="right" height="139" /></a>
+
+## Introduction
+
+`sweidnumbr` is an R package for structural handling of identity numbers used in the swedish administration such as personal identity numbers (personnummer) and organizational identity numbers (organisationsnummer).
+
+## Installation
+
+To install from CRAN just write:
+
+```r
+install.packages(sweidnumbr)
+```
+
+Use the `devtools` package to install the latest version from GitHub:
+
+```r
+devtools::install_github("rOpenGov/sweidnumbr")
+library(sweidnumbr)
+```
+
+A tutorial is included with the package and can be viewed with:
+```r
+vignette("sweidnumbr")
+```
+
+## Reporting bugs
+
+Please use the GitHub issue tracker [here](https://github.com/rOpenGov/sweidnumbr/issues) for reporting bugs and making further feature requests.
+
+IMPORTANT: When submitting a bug, you can make the lives of the developers easier by submitting the following information along with your bug report:
+
+- The output of `sessionInfo()`
+- The output of `packageVersion("sweidnumbr")`


### PR DESCRIPTION
I made slight alterations to existing GitHub workflows to allow for repository dispatch of pkgdown page build when Readme is changed. Maybe it's a bit overkill but hey, at least we have a nice automated system now in place. ;)

(Note to self: I might want to create a separate personal access token, PAT, with long expiry date for use these scripts so that I don't have to update them every 30 days. Using an organization secret did not work as repository dispatches need PATs)